### PR TITLE
Made playbook generic enough to handle arbitrary containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Generic Docker Container Boot Playbook
+This playbook can be used to launch an arbitrary docker container on a VM.
+It will first make sure that docker is installed on the target VM and then run
+the desired container on the VM.
+
+Playbook Variables
+-------------------
+
+| Variable              | Description                       | Example                                               |
+|-----------------------|-----------------------------------|-------------------------------------------------------|
+| docker_container_name | Name to give the docker container | cloudman-boot                                         |
+| docker_boot_image     | Image to run                      | cloudve/cloudman-boot:latest                          |
+| docker_volumes        | An array of volume mounts         | ['/var/run/docker.sock:/var/run/docker.sock']         |
+| docker_ports          | An array of port mappings         | ['8913:9000', '5678:5678']                            |
+| docker_env            | A dict of env vars                | {'CM_SKIP_CLOUDMAN': 'False', 'MY_OTHER_VAR': 'test'} |

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,5 +1,5 @@
 ---
-- name: Bootstrap CloudMan
+- name: Bootstrap Docker Container
   hosts: all
   become: yes
   gather_facts: false
@@ -53,7 +53,7 @@
         state: present
 
     # Note that this task does not wait for the container to exit/end execution
-    - name: Boot CloudMan
+    - name: "Boot Container {{ docker_container_name }}"
       docker_container:
         name: "{{ docker_container_name }}"
         image: "{{ docker_boot_image }}"

--- a/playbook.yml
+++ b/playbook.yml
@@ -55,17 +55,8 @@
     # Note that this task does not wait for the container to exit/end execution
     - name: Boot CloudMan
       docker_container:
-        name: cloudman-boot
-        image: "{{ cm_boot_image|default('galaxy/cloudman-boot') }}"
-        volumes:
-          - /var/run/docker.sock:/var/run/docker.sock
-        env:
-          RANCHER_SERVER: "{{ rancher_server }}"
-          RANCHER_PWD: "{{ rancher_pwd|default('Something-To-Change') }}"
-          CM_DEPLOYMENT_NAME: "{{ cm_deployment_name|default('', true) }}"
-          CM_INITIAL_CLUSTER_DATA: "{{ cm_initial_cluster_data|default('', true) }}"
-          CM_HELM_VALUES: "{{ cm_helm_values|default('', true) }}"
-          CM_SKIP_CLOUDMAN: "{{ cm_skip_cloudman|default('false', true) }}"
-          KUBE_CLOUD_PROVIDER: "{{ kube_cloud_provider|default('', true) }}"
-          KUBE_CLOUD_CONF: "{{ kube_cloud_conf|default('', true) }}"
-...
+        name: "{{ docker_container_name }}"
+        image: "{{ docker_boot_image }}"
+        volumes: "{{ docker_volumes|default([], true) }}"
+        published_ports: "{{ docker_ports|default([], true) }}"
+        env: "{{ docker_env|default({}, true) }}"


### PR DESCRIPTION
This will allow us to use a single playbook to boot all containers, and remove the need to pass each env var individually.